### PR TITLE
Create hosts and evidence

### DIFF
--- a/lib/dradis/plugins/netsparker/gem_version.rb
+++ b/lib/dradis/plugins/netsparker/gem_version.rb
@@ -8,8 +8,8 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 0
-        TINY = 0
+        MINOR = 7
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/netsparker/importer.rb
+++ b/lib/dradis/plugins/netsparker/importer.rb
@@ -19,20 +19,35 @@ module Dradis::Plugins::Netsparker
       end
 
       @doc.xpath('/netsparker/vulnerability').each do |xml_vuln|
-        process_vulnerability(xml_vuln)
+        # Create Nodes from the <url> tags
+        host_node_label = xml_vuln.at_xpath('./url').text
+        host_node_label = URI.parse(host_node_label).host rescue host_node_label
+        logger.info{ "\t\t => Creating new host: #{host_node_label}" }
+        host_node = content_service.create_node(label: host_node_label, type: :host)
+
+        # Extract the <type> value to use it as the plugin_id
+        type = xml_vuln.at_xpath('./type').text()
+
+        # Create Issues using the Issue template
+        logger.info{ "\t\t => Creating new issue (type: #{type})" }
+
+        issue_text = template_service.process_template(template: 'issue', data: xml_vuln)
+        issue = content_service.create_issue(text: issue_text, id: type)
+
+        # Create Evidence using the Evidence template
+        # Associate the Evidence with the Node and Issue
+        logger.info{ "\t\t => Creating new evidence" }
+        evidence_content = template_service.process_template(
+          template: 'evidence', data: xml_vuln
+        )
+        content_service.create_evidence(
+          issue: issue, node: host_node, content: evidence_content
+        )
+
       end
 
       return true
     end # /import
 
-    private
-    def process_vulnerability(xml_vuln)
-      type = xml_vuln.at_xpath('./type').text()
-
-      logger.info{ "\t\t => Creating new issue (type: #{type})" }
-
-      issue_text = template_service.process_template(template: 'issue', data: xml_vuln)
-      issue = content_service.create_issue(text: issue_text, id: type + rand(3).to_s)
-    end
   end
 end

--- a/lib/dradis/plugins/netsparker/importer.rb
+++ b/lib/dradis/plugins/netsparker/importer.rb
@@ -18,36 +18,47 @@ module Dradis::Plugins::Netsparker
         return false
       end
 
-      @doc.xpath('/netsparker/vulnerability').each do |xml_vuln|
-        # Create Nodes from the <url> tags
-        host_node_label = xml_vuln.at_xpath('./url').text
-        host_node_label = URI.parse(host_node_label).host rescue host_node_label
-        logger.info{ "\t\t => Creating new host: #{host_node_label}" }
-        host_node = content_service.create_node(label: host_node_label, type: :host)
-
-        # Extract the <type> value to use it as the plugin_id
-        type = xml_vuln.at_xpath('./type').text()
-
-        # Create Issues using the Issue template
-        logger.info{ "\t\t => Creating new issue (type: #{type})" }
-
-        issue_text = template_service.process_template(template: 'issue', data: xml_vuln)
-        issue = content_service.create_issue(text: issue_text, id: type)
-
-        # Create Evidence using the Evidence template
-        # Associate the Evidence with the Node and Issue
-        logger.info{ "\t\t => Creating new evidence" }
-        evidence_content = template_service.process_template(
-          template: 'evidence', data: xml_vuln
-        )
-        content_service.create_evidence(
-          issue: issue, node: host_node, content: evidence_content
-        )
-
+      @doc.xpath('/netsparker/target').each do |xml_host|
+        process_report_host(xml_host)
       end
 
       return true
     end # /import
+
+    private
+
+    def process_report_host(xml_host)
+      # Create Nodes from the <url> tags
+      host_node_label = xml_host.at_xpath('./url').text
+      host_node_label = URI.parse(host_node_label).host rescue host_node_label
+      logger.info{ "\t\t => Creating new host: #{host_node_label}" }
+      host_node = content_service.create_node(label: host_node_label, type: :host)
+
+      @doc.xpath('/netsparker/vulnerability').each do |xml_vuln|
+        process_vuln(xml_vuln, host_node)
+      end
+      
+    end
+
+    def process_vuln(xml_vuln, host_node)
+      type = xml_vuln.at_xpath('./type').text()
+
+      # Create Issues using the Issue template
+      logger.info{ "\t\t => Creating new Issue: #{type}" }
+
+      issue_text = template_service.process_template(template: 'issue', data: xml_vuln)
+      issue = content_service.create_issue(text: issue_text, id: type)
+
+      # Create Evidence using the Evidence template
+      # Associate the Evidence with the Node and Issue
+      logger.info{ "\t\t => Creating new evidence" }
+      evidence_content = template_service.process_template(
+        template: 'evidence', data: xml_vuln
+      )
+      content_service.create_evidence(
+        issue: issue, node: host_node, content: evidence_content
+      )
+    end
 
   end
 end

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -1,5 +1,5 @@
 class NetsparkerTasks < Thor
-  include Core::Pro::ProjectScopedTask if defined?(::Core::Pro)
+  include Rails.application.config.dradis.thor_helper_module
 
   namespace "dradis:plugins:netsparker"
 
@@ -15,22 +15,9 @@ class NetsparkerTasks < Thor
       exit -1
     end
 
-    content_service  = nil
-    template_service = Dradis::Pro::Plugins::TemplateService.new(plugin: Dradis::Plugins::Netsparker)
+    detect_and_set_project_scope
 
-    if defined?(Dradis::Pro)
-      detect_and_set_project_scope
-      content_service = Dradis::Pro::Plugins::ContentService.new(plugin: Dradis::Plugins::Netsparker)
-    else
-      content_service = Dradis::Plugins::ContentService.new(plugin: Dradis::Plugins::Netsparker)
-    end
-
-    importer = Dradis::Plugins::Netsparker::Importer.new(
-                logger: logger,
-       content_service: content_service,
-      template_service: template_service
-    )
-
+    importer = Dradis::Plugins::Netsparker::Importer.new(logger: logger)
     importer.import(file: file_path)
 
     logger.close

--- a/spec/fixtures/files/example-evidence.xml
+++ b/spec/fixtures/files/example-evidence.xml
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml-stylesheet href="vulnerabilities-list.xsl" type="text/xsl" ?>
+
+<netsparker generated="1.2.2017 12:34:45">
+	<target>
+		<url>https://snorby.org/</url>
+		<scantime>1470</scantime>
+	</target>
+				<vulnerability confirmed="False">
+					<url>https://snorby.org/foo</url>
+					<type>EmailDisclosure</type>
+					<severity>Information</severity>
+					<certainty>95</certainty>
+
+					<rawrequest><rawrequest><![CDATA[REDACTED}]]></rawrequest></rawrequest>
+					<rawresponse><rawrequest><![CDATA[REDACTED}]]></rawrequest></rawresponse>
+					<extrainformation>
+					</extrainformation>
+
+						<proofs></proofs>
+
+
+						<classification>
+							<OWASP2013></OWASP2013>
+							<WASC>13</WASC>
+							<CWE>200</CWE>
+							<CAPEC>118</CAPEC>
+							<PCI31></PCI31>
+							<PCI32></PCI32>
+							<HIPAA></HIPAA>
+							<OWASPPC>C7</OWASPPC>
+
+								<CVSS>
+									<vector>CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N</vector>
+
+									<score>
+										<type>Base</type>
+										<value>5.3</value>
+										<severity>Medium</severity>
+									</score>
+									<score>
+										<type>Temporal</type>
+										<value>5.3</value>
+										<severity>Medium</severity>
+									</score>
+									<score>
+										<type>Environmental</type>
+										<value>5.3</value>
+										<severity>Medium</severity>
+									</score>
+
+								</CVSS>
+						</classification>
+
+				</vulnerability>
+				<vulnerability confirmed="False">
+					<url>https://snorby.org/bar</url>
+					<type>EmailDisclosure</type>
+					<severity>Information</severity>
+					<certainty>95</certainty>
+
+					<rawrequest><rawrequest><![CDATA[REDACTED}]]></rawrequest></rawrequest>
+					<rawresponse><rawrequest><![CDATA[REDACTED}]]></rawrequest></rawresponse>
+					<extrainformation>
+							<info name="Email Address(es)"><![CDATA[info@snorby.org]]></info>
+					</extrainformation>
+
+						<proofs></proofs>
+
+
+						<classification>
+							<OWASP2013></OWASP2013>
+							<WASC>13</WASC>
+							<CWE>200</CWE>
+							<CAPEC>118</CAPEC>
+							<PCI31></PCI31>
+							<PCI32></PCI32>
+							<HIPAA></HIPAA>
+							<OWASPPC>C7</OWASPPC>
+
+						</classification>
+
+				</vulnerability>
+
+</netsparker>

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -1,0 +1,3 @@
+evidence.rawrequest
+evidence.rawresponse
+evidence.url

--- a/templates/evidence.sample
+++ b/templates/evidence.sample
@@ -1,0 +1,55 @@
+<vulnerability confirmed="False">
+  <url>http://test.testlab.com:3000/</url>
+  <type>MissingXssProtectionHeader</type>
+  <severity>Information</severity>
+  <certainty>100</certainty>
+  ​<description><![CDATA[<p>Netsparker detected a missing <code>X-XSS-Protection</code> header which means that this website could be at risk of a Cross-site Scripting (XSS) attacks.</p>]]></description>
+  <remedy><![CDATA[<div>Add the X-XSS-Protection header with a value of "1; mode= block".<ul><li><pre class="code">X-XSS-Protection: 1; mode=block</pre></li></ul></div>]]></remedy>
+
+  <rawrequest><![CDATA[GET /javascripts/responsive.js HTTP/1.1
+Host: test.testlab.com:3000
+Cache-Control: no-cache
+Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+User-Agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.16 Safari/537.36
+Accept-Language: en-us,en;q=0.5
+X-Scanner: Netsparker
+Cookie: _redmine_session=V2tvR3dUZ
+Accept-Encoding: gzip, deflate
+
+]]></rawrequest>
+  <rawresponse><![CDATA[HTTP/1.1 200 OK
+Server: WEBrick/1.3.1 (Ruby/2.3.0/2015-12-25)
+Connection: Keep-Alive
+Content-Length: 2002
+Last-Modified: Sun, 19 Jun 2016 12:47:24 GMT
+Content-Type: application/javascript
+Date: Wed, 08 Feb 2017 20:49:45 GMT
+
+// generic layout specific responsive stuff goes here
+
+function openFlyout() {
+  $('html').addClass('flyout-is-active');
+  $('#wrapper2').on('click', function(e){
+    e.preventDefault();
+    e.stopPropagation();
+    closeFlyout();
+  });
+}
+]]></rawresponse>
+  <extrainformation></extrainformation>
+
+  <proofs></proofs>
+
+
+  <classification>
+    <OWASP2013></OWASP2013>
+    <WASC></WASC>
+    <CWE></CWE>
+    <CAPEC></CAPEC>
+    <PCI31></PCI31>
+    <PCI32></PCI32>
+    <HIPAA>164.308(a)</HIPAA>
+    <OWASPPC>C9</OWASPPC>
+  </classification>
+
+</vulnerability>

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -1,5 +1,8 @@
+#[URL]#
+%evidence.url%
+
 #[Request]#
-bc.. %issue.rawrequest%
+bc.. %evidence.rawrequest%
 
 #[Response]#
-bc.. %issue.rawresponse%
+bc.. %evidence.rawresponse%

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -1,0 +1,5 @@
+#[Request]#
+bc.. %issue.rawrequest%
+
+#[Response]#
+bc.. %issue.rawresponse%

--- a/templates/issue.fields
+++ b/templates/issue.fields
@@ -8,8 +8,6 @@ issue.classification_pci31
 issue.classification_pci32
 issue.classification_wasc
 issue.description
-issue.rawrequest
-issue.rawresponse
 issue.remedy
 issue.severity
 issue.title

--- a/templates/issue.template
+++ b/templates/issue.template
@@ -13,9 +13,3 @@
 #[Remedy]#
 %issue.remedy%
 
-
-#[Request]#
-bc.. %issue.rawrequest%
-
-#[Response]#
-bc.. %issue.rawresponse%


### PR DESCRIPTION
This PR adds an Evidence template to the Plugin Manager so the Request/Response data can be added into instances of Evidence rather than creating duplicate Issues. 

