### PR TITLE
Create bullet lists instead of numbered lists

### DIFF
--- a/lib/netsparker/vulnerability.rb
+++ b/lib/netsparker/vulnerability.rb
@@ -140,7 +140,7 @@ module Netsparker
       result.gsub!(/<p (.*?)>(.*?)<\/p>/) { "\n#{$2}\n" }
       result.gsub!(/<span(.*?)>(.*?)<\/span>/, '\2')
       result.gsub!(/(<p>)|(<\/p>)/, "\n")
-      result.gsub!(/\n[a-z]\. /, "\n\# ")
+      result.gsub!(/\n[a-z]\. /, "\n\* ")
 
       result.gsub!(/<a href=\"(.*?)\" (.*?)>(.*?)<\/a>/i) { "\"#{$3.strip}\":#{$1.strip}" }
       result.gsub!(/<a href=\'(.*?)\'>(.*?)<\/a>/i) { "\"#{$2.strip}\":#{$1.strip}" }


### PR DESCRIPTION
When a lettered list exists like: 

```
a. list item
b. another list item
```

We should import it as a bullet list rather than a numbered list. This prevents the list from restarting at 1 multiple time when there's >1 paragraph in between each list item. 