### PR TITLE
Add support to new tags: :vulnerableparameter, :vulnerableparametertype, :vulnerableparametervalue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Dradis Framework 3.13 (XXXX, 2019)
 
 * Add Known Vulnerabilities and OWASP 2017 Classification as available Issue fields
+* Add :vulnerableparameter, :vulnerableparametertype, and :vulnerableparametervalue Evidence fields
 
 ## Dradis Framework 3.12 (March, 2019)
 

--- a/lib/netsparker/vulnerability.rb
+++ b/lib/netsparker/vulnerability.rb
@@ -27,7 +27,7 @@ module Netsparker
         :extrainformation, :impact, :knownvulnerabilities, 
         :rawrequest, :rawresponse, :remedy,
         :remedy_references, :required_skills_for_exploitation, :severity,
-        :type, :url,
+        :type, :url, :vulnerableparameter, :vulnerableparametertype, :vulnerableparametervalue,
 
         # tags that correspond to Evidence
 

--- a/lib/netsparker/vulnerability.rb
+++ b/lib/netsparker/vulnerability.rb
@@ -27,9 +27,10 @@ module Netsparker
         :extrainformation, :impact, :knownvulnerabilities, 
         :rawrequest, :rawresponse, :remedy,
         :remedy_references, :required_skills_for_exploitation, :severity,
-        :type, :url, :vulnerableparameter, :vulnerableparametertype, :vulnerableparametervalue,
+        :type, :url,
 
         # tags that correspond to Evidence
+        :vulnerableparameter, :vulnerableparametertype, :vulnerableparametervalue,
 
         # nested tags
         :classification_capec,

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -1,3 +1,6 @@
 evidence.rawrequest
 evidence.rawresponse
 evidence.url
+evidence.vulnerableparameter
+evidence.vulnerableparametertype
+evidence.vulnerableparametervalue

--- a/templates/evidence.sample
+++ b/templates/evidence.sample
@@ -6,6 +6,9 @@
   ​<description><![CDATA[<p>Netsparker detected a missing <code>X-XSS-Protection</code> header which means that this website could be at risk of a Cross-site Scripting (XSS) attacks.</p>]]></description>
   <remedy><![CDATA[<div>Add the X-XSS-Protection header with a value of "1; mode= block".<ul><li><pre class="code">X-XSS-Protection: 1; mode=block</pre></li></ul></div>]]></remedy>
 
+  <vulnerableparametertype>GET</vulnerableparametertype>
+  <vulnerableparameter>value</vulnerableparameter>
+  <vulnerableparametervalue>1;expr 268409241 - 85983;x</vulnerableparametervalue>
   <rawrequest><![CDATA[GET /javascripts/responsive.js HTTP/1.1
 Host: test.testlab.com:3000
 Cache-Control: no-cache

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -6,3 +6,12 @@ bc.. %evidence.rawrequest%
 
 #[Response]#
 bc.. %evidence.rawresponse%
+
+#[VulnerableParameter]#
+bc.. evidence.vulnerableparameter
+
+#[VulnerableParameterType]#
+bc.. evidence.vulnerableparametertype
+
+#[VulnerableParameterValue]#
+bc.. evidence.vulnerableparametervalue

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -8,10 +8,10 @@ bc.. %evidence.rawrequest%
 bc.. %evidence.rawresponse%
 
 #[VulnerableParameter]#
-bc.. evidence.vulnerableparameter
+bc. %evidence.vulnerableparameter%
 
 #[VulnerableParameterType]#
-bc.. evidence.vulnerableparametertype
+bc. %evidence.vulnerableparametertype%
 
 #[VulnerableParameterValue]#
-bc.. evidence.vulnerableparametervalue
+bc. %evidence.vulnerableparametervalue%


### PR DESCRIPTION
It seems there are a few new tags that Netsparker provides that we were not parsing before.