### PR TITLE
Use new Title tag rather than the old Type tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.16 (XXXX, 2020) ##
+
+* Use the new built-in Title tag rather than the Type tag
+
 ## Dradis Framework 3.15 (November, 2019) ##
 
 *   Fix link parsing of issue.external_references

--- a/lib/dradis/plugins/netsparker/gem_version.rb
+++ b/lib/dradis/plugins/netsparker/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 15
-        TINY = 1
+        TINY = 0
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/netsparker/gem_version.rb
+++ b/lib/dradis/plugins/netsparker/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 15
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/netsparker/vulnerability.rb
+++ b/lib/netsparker/vulnerability.rb
@@ -96,9 +96,6 @@ module Netsparker
       }
       method_name = translations_table.fetch(method, method.to_s)
 
-      # We've previously had a virtual method :title which wasn't provided by Netsparker but that most users were expecting.
-      #return type.underscore.humanize if method == :title
-
       # first we try the attributes:
       # return @xml.attributes[method_name].value if @xml.attributes.key?(method_name)
 

--- a/lib/netsparker/vulnerability.rb
+++ b/lib/netsparker/vulnerability.rb
@@ -19,15 +19,12 @@ module Netsparker
     # collections.
     def supported_tags
       [
-        # made-up tags
-        :title,
-
         # simple tags
         :actions_to_take, :certainty, :description, :external_references,
         :extrainformation, :impact, :knownvulnerabilities,
         :rawrequest, :rawresponse, :remedy,
         :remedy_references, :required_skills_for_exploitation, :severity,
-        :type, :url,
+        :title, :type, :url,
 
         # tags that correspond to Evidence
         :vulnerableparameter, :vulnerableparametertype, :vulnerableparametervalue,
@@ -99,9 +96,8 @@ module Netsparker
       }
       method_name = translations_table.fetch(method, method.to_s)
 
-      # We've got a virtual method :title which isn't provided by Netsparker
-      # but that most users will be expecting.
-      return type.underscore.humanize if method == :title
+      # We've previously had a virtual method :title which wasn't provided by Netsparker but that most users were expecting.
+      #return type.underscore.humanize if method == :title
 
       # first we try the attributes:
       # return @xml.attributes[method_name].value if @xml.attributes.key?(method_name)


### PR DESCRIPTION
### Summary
Previously, there was no `<title>` tag in Netsparker XML output so we were pulling the Issue title from the existing `<type>` tag in the XML output. This had issues like inconsistent capitalization. Now, a `<title>` field exists that can be pulled in immediately and easily that is formatted nicely for humans. 

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
