### PR TITLE
Update nokogiri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Dradis Framework 3.23 (XXXX, 2021) ##
 
-*   Add new issue.classification_asvs40, issue.classification_nistsp80053, issue.classification_disastig, and issue.classification_iso27001 fields. 
+*   Add new issue.classification_asvs40, issue.classification_nistsp80053, issue.classification_disastig, and issue.classification_iso27001 fields.
+*   Update nokogiri dependency.
 
 ## Dradis Framework 3.22 (April, 2021) ##
 

--- a/dradis-netsparker.gemspec
+++ b/dradis-netsparker.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # until we bump Dradis Pro to 4.1.
   # s.add_dependency 'rails', '~> 4.1.1'
   spec.add_dependency 'dradis-plugins', '~> 3.2'
-  spec.add_dependency 'nokogiri', '~> 1.10.4'
+  spec.add_dependency 'nokogiri', '~> 1.11.4'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
### Summary
This PR updates nokogiri version due to CVE. https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-7rrm-v45f-jp64

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
