### PR TITLE
Add evidence.extrainformation & evidence.proofs as available fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v#.#.# (MMMM YYYY)
+  - Add `evidence.extrainformation` & `evidence.proofs` as available fields
+
 v4.9.0 (June 2023)
   - No changes
 

--- a/lib/dradis/plugins/netsparker/gem_version.rb
+++ b/lib/dradis/plugins/netsparker/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 9
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/netsparker/vulnerability.rb
+++ b/lib/netsparker/vulnerability.rb
@@ -43,6 +43,7 @@ module Netsparker
         :classification_owasppc, :classification_pci31, :classification_pci32, :classification_wasc,
 
         # multiple tags
+        :extrainformation, :proofs,
       ]
     end
 
@@ -109,7 +110,7 @@ module Netsparker
       tag = xml.at_xpath("./#{method_name}")
       if tag && !tag.text.blank?
         text = tag.text
-        return tags_with_html_content.include?(method) ? cleanup_html(text) : text
+        return tags_with_nested_content.include?(method) ? cleanup_nested(text) : (return tags_with_html_content.include?(method) ? cleanup_html(text) : text)
       else
         return 'n/a'
       end
@@ -159,12 +160,23 @@ module Netsparker
       result
     end
 
-    # Some of the values have embedded HTML conent that we need to strip
+    def cleanup_nested(source)
+      result = source.dup
+      result.gsub!(/^\s+/, "")
+      result
+    end
+
+    # Some of the values have embedded HTML content that we need to strip
     def tags_with_html_content
       [
         :actions_to_take, :description, :external_references, :extrainformation,
         :impact, :remedy, :remedy_references, :required_skills_for_exploitation
       ]
     end
+
+    def tags_with_nested_content
+      [ :extrainformation, :proofs ]
+    end
+
   end
 end

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -1,3 +1,5 @@
+evidence.extrainformation
+evidence.proofs
 evidence.rawrequest
 evidence.rawresponse
 evidence.url

--- a/templates/evidence.sample
+++ b/templates/evidence.sample
@@ -39,11 +39,18 @@ function openFlyout() {
   });
 }
 ]]></rawresponse>
-  <extrainformation></extrainformation>
-
-  <proofs></proofs>
-
-
+  <extrainformation>
+      <info>
+          <name>Example Name</name>
+          <value><![CDATA[Example Value]]></value>
+      </info>
+  </extrainformation>
+  <proofs>
+      <proof>
+          <key><![CDATA[example key]]></key>
+          <value><![CDATA[example value.]]></value>
+      </proof>
+  </proofs>
   <classification>
     <OWASP2013></OWASP2013>
     <WASC></WASC>


### PR DESCRIPTION
### Summary
This PR adds support for the following fields: 
- `evidence.extrainformation`
- `evidence.proofs`

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
