### PR TITLE
Add extrainformation as an evidence field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.X.X (XXXX 2024)
+ - Add evidence.extrainformation as an available field
+
 v4.12.0 (May 2024)
  - Migrate integration to use Mappings Manager
  - Update Dradis links in README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-v4.X.X (XXXX 2024)
- - Add evidence.extrainformation as an available field
+v4.13.0 (XXXX 2024)
+ - Add extrainformation as an available evidence field
 
 v4.12.0 (May 2024)
  - Migrate integration to use Mappings Manager

--- a/lib/dradis/plugins/netsparker/gem_version.rb
+++ b/lib/dradis/plugins/netsparker/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 12
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/netsparker/gem_version.rb
+++ b/lib/dradis/plugins/netsparker/gem_version.rb
@@ -8,8 +8,8 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 12
-        TINY = 1
+        MINOR = 13
+        TINY = 0
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/netsparker/mapping.rb
+++ b/lib/dradis/plugins/netsparker/mapping.rb
@@ -2,6 +2,7 @@ module Dradis::Plugins::Netsparker
   module Mapping
     DEFAULT_MAPPING = {
       evidence: {
+        'ExtraInformation' => '{{ netsparker[evidence.extrainformation] }}',
         'URL' => '{{ netsparker[evidence.url] }}',
         'Request' => 'bc.. {{ netsparker[evidence.rawrequest] }}',
         'Response' => 'bc.. {{ netsparker[evidence.rawresponse] }}',
@@ -20,6 +21,7 @@ module Dradis::Plugins::Netsparker
 
     SOURCE_FIELDS = {
       evidence: [
+        'evidence.extrainformation',
         'evidence.rawrequest',
         'evidence.rawresponse',
         'evidence.url',


### PR DESCRIPTION
### Summary
The `extrainformation` changes from one instance to the next and therefore belongs under the Evidence, not just the Issue. 


### Testing Steps

1. Configure the Mappings Manager to include the `extrainformation` at the Evidence level
2. Upload the following file to your project: https://github.com/dradis/dradis-netsparker/blob/main/spec/fixtures/files/testsparker.xml
3. Open the XSS Issue and the associated Evidence. Confirm that each instance of Evidence has a different value for the extrainformation


### Copyright assignment
> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List
- [x] Added a CHANGELOG entry
- [x] Added specs (none needed)